### PR TITLE
Migrate to nvim-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ require'cmp'.setup {
 
 ## Configuration
 
-To configure this extension, change the `tmux` compe source definition as defined below (defaults shown).
+To configure this extension, add an options table (defaults shown):
 
 ```lua
 require'compe'.setup {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # compe-tmux
 
-Tmux completion source for [nvim-compe](https://github.com/hrsh7th/nvim-compe).
+Tmux completion source for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 
 *By default this extension uses adjacent panes as sources. See [configuration](#configuration)
 to enable all panes.*
@@ -8,7 +8,7 @@ to enable all panes.*
 ## Requirements
 
 * [Neovim](https://github.com/neovim/neovim/)
-* [nvim-compe](https://github.com/hrsh7th/nvim-compe)
+* [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 * [tmux](https://github.com/tmux/tmux)
 
 ## Installation
@@ -16,52 +16,34 @@ to enable all panes.*
 Use your package manager of choice. For example [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
 ```vim
-use 'andersevenrud/compe-tmux'
+use 'andersevenrud/compe-tmux#refactor/nvim-cmp'
 ```
 
 ## Setup
 
-Using Lua:
-
 ```lua
-require'compe'.setup {
-  source = {
-    tmux = true,
+require'cmp'.setup {
+  sources = {
+    { name = 'tmux' }
   }
 }
-```
-
-Or Vimscript:
-
-```vim
-let g:compe.source.tmux = v:true
 ```
 
 ## Configuration
 
 To configure this extension, change the `tmux` compe source definition as defined below (defaults shown).
 
-Using Lua:
-
 ```lua
 require'compe'.setup {
-  source = {
-    tmux = {
-      disabled = false,
-      all_panes = false,
-      kind = 'Text',
+  sources = {
+    {
+      name = 'tmux',
+      opts = {
+        all_panes = false,
+      }
     }
   }
 }
-```
-
-Or using Vimscript:
-
-```vim
-let g:compe.source.tmux = {}
-let g:compe.source.tmux.disabled = v:false
-let g:compe.source.tmux.all_panes = v:false
-let g:compe.source.tmux.kind = "Text"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ to enable all panes.*
 
 Use your package manager of choice. For example [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
-```vim
-use 'andersevenrud/compe-tmux#refactor/nvim-cmp'
+```lua
+use {
+  'andersevenrud/compe-tmux',
+  branch = 'refactor/nvim-cmp'
+}
 ```
 
 ## Setup

--- a/after/plugin/compe_tmux.vim
+++ b/after/plugin/compe_tmux.vim
@@ -1,8 +1,6 @@
-if exists('g:loaded_compe_tmux')
+if exists('g:loaded_cmp_tmux')
   finish
 endif
-let g:loaded_compe_tmux = v:true
+let g:loaded_cmp_tmux = v:true
 
-if exists('g:loaded_compe')
-  lua require'compe'.register_source('tmux', require'compe_tmux')
-endif
+lua require'cmp'.register_source('tmux', require'compe_tmux')

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -5,41 +5,49 @@
 -- license: MIT
 --
 
-local compe = require'compe'
 local utils = require'compe_tmux.utils'
 local Tmux = require'compe_tmux.tmux'
 
-local Source = {}
+local source = {}
 
-function Source.new()
-    local self = setmetatable({}, { __index = Source })
+source.new = function()
+    local self = setmetatable({}, { __index = source })
     local config = utils.create_compe_config()
     self.tmux = Tmux.new(config)
     return self
 end
 
-function Source.get_metadata(self)
-    return {
-        priority = 100,
-        dup = 0,
-        menu = '[tmux]'
-    }
+source.get_debug_name = function()
+    return 'tmux'
 end
 
-function Source.determine(self, context)
-    return compe.helper.determine(context)
+function source:is_available()
+    return self.tmux:is_enabled()
 end
 
-function Source.complete(self, args)
-    local items = self.tmux:complete(args.input)
+function source:get_keyword_pattern()
+  return [[\w\+]]
+end
+
+function source:get_trigger_characters()
+  return { '.' }
+end
+
+function source:complete(request, callback)
+    local items = self.tmux:complete(request.context.cursor_line)
     if items == nil then
-        return args.abort()
+        return callback()
     end
 
-    args.callback({
-        incomplete = true,
-        items = items
-    })
+    callback(items)
 end
 
-return Source
+function source:resolve(completion_item, callback)
+    callback(completion_item)
+end
+
+function source:execute(completion_item, callback)
+    callback(completion_item)
+end
+
+return source

--- a/lua/compe_tmux/tmux.lua
+++ b/lua/compe_tmux/tmux.lua
@@ -61,31 +61,28 @@ function Tmux.get_completion_items(self, current_pane, input)
                 local word_lower = word:lower()
 
                 if word_lower:match(input_lower) then
-                    table.insert(result, {
-                        word = word:gsub('[:.]+$', ''),
-                        kind = self.config.kind,
-                    })
+                    local clean_word = word:gsub('[:.]+$', '')
+                    result[clean_word] = {
+                        word = clean_word,
+                        label = clean_word,
+                    }
 
                     -- but also isolate the words from the result
                     for sub_word in string.gmatch(word, '[%w%d]+') do
-                        table.insert(result, {
+                        result[sub_word] = {
                             word = sub_word,
-                            kind = self.config.kind,
-                        })
+                            label = sub_word,
+                        }
                     end
                 end
             end
         end
     end
 
-    return result
+    return vim.tbl_values(result)
 end
 
 function Tmux.complete(self, input)
-    if not self:is_enabled() then
-        return nil
-    end
-
     local current_pane = self:get_current_pane()
     if not current_pane then
         return nil

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -6,7 +6,11 @@
 --
 
 local Utils = {}
-local compe_config = require'compe.config'
+local config = require'cmp.config'
+
+local default_config = {
+    all_panes = false,
+}
 
 Utils.read_command = function(cmd)
     local h = io.popen(cmd)
@@ -23,17 +27,8 @@ Utils.read_command = function(cmd)
 end
 
 Utils.create_compe_config = function()
-    local source = {}
-    local c = compe_config.get()
-
-    if type(c) == 'table' and type(c.source) == 'table' then
-        source = c.source.tmux or {}
-    end
-
-    return vim.tbl_extend('force', {
-        all_panes = false,
-        kind = 'Text'
-    }, source)
+    local source = config.get_source_option('tmux') or {}
+    return vim.tbl_extend('force', default_config, source)
 end
 
 return Utils


### PR DESCRIPTION
This should make this extension run on cmp. This repo will be renamed and rebased when cmp is ready.... is it ready ?! I can't really tell :man_shrugging: 

**[New installation instructions](https://github.com/andersevenrud/compe-tmux/blob/refactor/nvim-cmp/README.md)**

Breaking:

- The option `kind` is no longer overridable

Tasks:

- [x] Update main branch README with notice
- [x] Update new branch README instructions
- [x] Remove obsolete 'kind' configuration
- [x] Migrate source
- [x] Migrate configuration
- [ ] Switch branches and rename project when cmp goes out

Additional (maybe another PR for this):

- [ ] Add better triggers now that this has a nicer API
- [ ] Is it possible to add menu hint like before (`[tmux]`) ? 
- [ ] Check if there's an internal dedupe? I could not figure that out from the initial skip of API
- [ ] Async task in cmp ?