### PR TITLE
Migrate to nvim-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ require'cmp'.setup {
       name = 'tmux',
       opts = {
         all_panes = false,
-        label = '[tmux]'
+        label = '[tmux]',
+        trigger_characters = { '.' },
+        trigger_characters_ft = {} -- { filetype = { '.' } }
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # compe-tmux
 
-Tmux completion source for [nvim-compe](https://github.com/hrsh7th/nvim-compe).
+Tmux completion source for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 
 **If you're looking for a [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) version of this extension, use the [following branch](https://github.com/andersevenrud/compe-tmux/tree/cmp)** ([more information](https://github.com/andersevenrud/compe-tmux/pull/8)).
 
@@ -10,7 +10,7 @@ to enable all panes.*
 ## Requirements
 
 * [Neovim](https://github.com/neovim/neovim/)
-* [nvim-compe](https://github.com/hrsh7th/nvim-compe)
+* [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 * [tmux](https://github.com/tmux/tmux)
 
 ## Installation
@@ -18,52 +18,34 @@ to enable all panes.*
 Use your package manager of choice. For example [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
 ```vim
-use 'andersevenrud/compe-tmux'
+use 'andersevenrud/compe-tmux#refactor/nvim-cmp'
 ```
 
 ## Setup
 
-Using Lua:
-
 ```lua
-require'compe'.setup {
-  source = {
-    tmux = true,
+require'cmp'.setup {
+  sources = {
+    { name = 'tmux' }
   }
 }
-```
-
-Or Vimscript:
-
-```vim
-let g:compe.source.tmux = v:true
 ```
 
 ## Configuration
 
 To configure this extension, change the `tmux` compe source definition as defined below (defaults shown).
 
-Using Lua:
-
 ```lua
 require'compe'.setup {
-  source = {
-    tmux = {
-      disabled = false,
-      all_panes = false,
-      kind = 'Text',
+  sources = {
+    {
+      name = 'tmux',
+      opts = {
+        all_panes = false,
+      }
     }
   }
 }
-```
-
-Or using Vimscript:
-
-```vim
-let g:compe.source.tmux = {}
-let g:compe.source.tmux.disabled = v:false
-let g:compe.source.tmux.all_panes = v:false
-let g:compe.source.tmux.kind = "Text"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ to enable all panes.*
 
 Use your package manager of choice. For example [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
-```vim
-use 'andersevenrud/compe-tmux#refactor/nvim-cmp'
+```lua
+use {
+  'andersevenrud/compe-tmux',
+  branch = 'refactor/nvim-cmp'
+}
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# compe-tmux
+# cmp-tmux
 
 Tmux completion source for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 
-**If you're looking for a [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) version of this extension, use the [following branch](https://github.com/andersevenrud/compe-tmux/tree/cmp)** ([more information](https://github.com/andersevenrud/compe-tmux/pull/8)).
+**If you're looking for a [nvim-compe](https://github.com/hrsh7th/nvim-compe) version of this extension, use the [following branch](https://github.com/andersevenrud/compe-tmux/tree/main)** ([more information](https://github.com/andersevenrud/compe-tmux/pull/8)).
 
 *By default this extension uses adjacent panes as sources. See [configuration](#configuration)
 to enable all panes.*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use your package manager of choice. For example [packer.nvim](https://github.com
 ```lua
 use {
   'andersevenrud/compe-tmux',
-  branch = 'refactor/nvim-cmp'
+  branch = 'cmp'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require'cmp'.setup {
 
 ## Configuration
 
-To configure this extension, change the `tmux` compe source definition as defined below (defaults shown).
+To configure this extension, add an options table (defaults shown):
 
 ```lua
 require'compe'.setup {

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ require'cmp'.setup {
 To configure this extension, add an options table (defaults shown):
 
 ```lua
-require'compe'.setup {
+require'cmp'.setup {
   sources = {
     {
       name = 'tmux',
       opts = {
         all_panes = false,
+        label = '[tmux]'
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tmux completion source for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 
-**If you're looking for a [nvim-compe](https://github.com/hrsh7th/nvim-compe) version of this extension, use the [following branch](https://github.com/andersevenrud/compe-tmux/tree/main)** ([more information](https://github.com/andersevenrud/compe-tmux/pull/8)).
+**If you're looking for a [nvim-compe](https://github.com/hrsh7th/nvim-compe) version of this extension, use the [following branch](https://github.com/andersevenrud/compe-tmux/tree/compe)**.
 
 *By default this extension uses adjacent panes as sources. See [configuration](#configuration)
 to enable all panes.*
@@ -19,8 +19,7 @@ Use your package manager of choice. For example [packer.nvim](https://github.com
 
 ```lua
 use {
-  'andersevenrud/compe-tmux',
-  branch = 'cmp'
+  'andersevenrud/compe-tmux'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require'cmp'.setup {
   sources = {
     {
       name = 'tmux',
-      opts = {
+      option = {
         all_panes = false,
         label = '[tmux]',
         trigger_characters = { '.' },

--- a/after/plugin/compe_tmux.vim
+++ b/after/plugin/compe_tmux.vim
@@ -1,8 +1,6 @@
-if exists('g:loaded_compe_tmux')
+if exists('g:loaded_cmp_tmux')
   finish
 endif
-let g:loaded_compe_tmux = v:true
+let g:loaded_cmp_tmux = v:true
 
-if exists('g:loaded_compe')
-  lua require'compe'.register_source('tmux', require'compe_tmux')
-endif
+lua require'cmp'.register_source('tmux', require'compe_tmux')

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -5,41 +5,49 @@
 -- license: MIT
 --
 
-local compe = require'compe'
 local utils = require'compe_tmux.utils'
 local Tmux = require'compe_tmux.tmux'
 
-local Source = {}
+local source = {}
 
-function Source.new()
-    local self = setmetatable({}, { __index = Source })
+source.new = function()
+    local self = setmetatable({}, { __index = source })
     local config = utils.create_compe_config()
     self.tmux = Tmux.new(config)
     return self
 end
 
-function Source.get_metadata(self)
-    return {
-        priority = 100,
-        dup = 0,
-        menu = '[tmux]'
-    }
+source.get_debug_name = function()
+    return 'tmux'
 end
 
-function Source.determine(self, context)
-    return compe.helper.determine(context)
+function source:is_available()
+    return self.tmux:is_enabled()
 end
 
-function Source.complete(self, args)
-    local items = self.tmux:complete(args.input)
+function source:get_keyword_pattern()
+  return [[\w\+]]
+end
+
+function source:get_trigger_characters()
+  return { '.' }
+end
+
+function source:complete(request, callback)
+    local items = self.tmux:complete(request.context.cursor_line)
     if items == nil then
-        return args.abort()
+        return callback()
     end
 
-    args.callback({
-        incomplete = true,
-        items = items
-    })
+    callback(items)
 end
 
-return Source
+function source:resolve(completion_item, callback)
+    callback(completion_item)
+end
+
+function source:execute(completion_item, callback)
+    callback(completion_item)
+end
+
+return source

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -31,7 +31,9 @@ function source:get_keyword_pattern()
 end
 
 function source:get_trigger_characters()
-  return { '.' }
+    local ft = vim.bo.filetype
+    local tcft = self.config.trigger_characters_ft[ft]
+    return tcft or self.config.trigger_characters
 end
 
 function source:complete(request, callback)

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -14,6 +14,7 @@ source.new = function()
     local self = setmetatable({}, { __index = source })
     local config = utils.create_compe_config()
     self.tmux = Tmux.new(config)
+    self.config = config
     return self
 end
 
@@ -35,7 +36,16 @@ end
 
 function source:complete(request, callback)
     local word = string.sub(request.context.cursor_before_line, request.offset)
-    local items = self.tmux:complete(word)
+    local words = self.tmux:complete(word)
+    local items = vim.tbl_map(function(word)
+        return {
+            word = word,
+            label = word,
+            labelDetails = {
+                detail = self.config.label
+            }
+        }
+    end, words)
     if items == nil then
         return callback()
     end

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -39,6 +39,10 @@ end
 function source:complete(request, callback)
     local word = string.sub(request.context.cursor_before_line, request.offset)
     local words = self.tmux:complete(word)
+    if words == nil then
+        return callback()
+    end
+
     local items = vim.tbl_map(function(word)
         return {
             word = word,
@@ -48,9 +52,6 @@ function source:complete(request, callback)
             }
         }
     end, words)
-    if items == nil then
-        return callback()
-    end
 
     callback(items)
 end

--- a/lua/compe_tmux/source.lua
+++ b/lua/compe_tmux/source.lua
@@ -34,7 +34,8 @@ function source:get_trigger_characters()
 end
 
 function source:complete(request, callback)
-    local items = self.tmux:complete(request.context.cursor_line)
+    local word = string.sub(request.context.cursor_before_line, request.offset)
+    local items = self.tmux:complete(word)
     if items == nil then
         return callback()
     end

--- a/lua/compe_tmux/tmux.lua
+++ b/lua/compe_tmux/tmux.lua
@@ -62,11 +62,13 @@ function Tmux.get_completion_items(self, current_pane, input)
 
                 if word_lower:match(input_lower) then
                     local clean_word = word:gsub('[:.]+$', '')
-                    result[clean_word] = true
+                    if #clean_word > 0 then
+                        result[clean_word] = true
 
-                    -- but also isolate the words from the result
-                    for sub_word in string.gmatch(word, '[%w%d]+') do
-                        result[sub_word] = true
+                        -- but also isolate the words from the result
+                        for sub_word in string.gmatch(word, '[%w%d]+') do
+                            result[sub_word] = true
+                        end
                     end
                 end
             end

--- a/lua/compe_tmux/tmux.lua
+++ b/lua/compe_tmux/tmux.lua
@@ -79,12 +79,16 @@ function Tmux.get_completion_items(self, current_pane, input)
 end
 
 function Tmux.complete(self, input)
-    local current_pane = self:get_current_pane()
-    if not current_pane then
-        return nil
+    if self:is_enabled() then
+        local current_pane = self:get_current_pane()
+        -- if not current_pane then
+        --     return nil
+        -- end
+
+        return self:get_completion_items(current_pane, input)
     end
 
-    return self:get_completion_items(current_pane, input)
+    return nil
 end
 
 return Tmux

--- a/lua/compe_tmux/tmux.lua
+++ b/lua/compe_tmux/tmux.lua
@@ -62,24 +62,18 @@ function Tmux.get_completion_items(self, current_pane, input)
 
                 if word_lower:match(input_lower) then
                     local clean_word = word:gsub('[:.]+$', '')
-                    result[clean_word] = {
-                        word = clean_word,
-                        label = clean_word,
-                    }
+                    result[clean_word] = true
 
                     -- but also isolate the words from the result
                     for sub_word in string.gmatch(word, '[%w%d]+') do
-                        result[sub_word] = {
-                            word = sub_word,
-                            label = sub_word,
-                        }
+                        result[sub_word] = true
                     end
                 end
             end
         end
     end
 
-    return vim.tbl_values(result)
+    return vim.tbl_keys(result)
 end
 
 function Tmux.complete(self, input)

--- a/lua/compe_tmux/tmux.lua
+++ b/lua/compe_tmux/tmux.lua
@@ -61,31 +61,28 @@ function Tmux.get_completion_items(self, current_pane, input)
                 local word_lower = word:lower()
 
                 if word_lower:match(input_lower) then
-                    table.insert(result, {
-                        word = word:gsub('[:.]+$', ''),
-                        kind = self.config.kind,
-                    })
+                    local clean_word = word:gsub('[:.]+$', '')
+                    result[clean_word] = {
+                        word = clean_word,
+                        label = clean_word,
+                    }
 
                     -- but also isolate the words from the result
                     for sub_word in string.gmatch(word, '[%w%d]+') do
-                        table.insert(result, {
+                        result[sub_word] = {
                             word = sub_word,
-                            kind = self.config.kind,
-                        })
+                            label = sub_word,
+                        }
                     end
                 end
             end
         end
     end
 
-    return result
+    return vim.tbl_values(result)
 end
 
 function Tmux.complete(self, input)
-    if not self:is_enabled() then
-        return nil
-    end
-
     local current_pane = self:get_current_pane()
     if not current_pane then
         return nil

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -10,7 +10,9 @@ local config = require'cmp.config'
 
 local default_config = {
     all_panes = false,
-    label = '[tmux]'
+    label = '[tmux]',
+    trigger_characters = { '.' },
+    trigger_characters_ft = {}
 }
 
 Utils.read_command = function(cmd)

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -10,6 +10,7 @@ local config = require'cmp.config'
 
 local default_config = {
     all_panes = false,
+    label = '[tmux]'
 }
 
 Utils.read_command = function(cmd)

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -31,7 +31,7 @@ end
 
 Utils.create_compe_config = function()
     local source = config.get_source_config('tmux') or {}
-    return vim.tbl_extend('force', default_config, source.opts)
+    return vim.tbl_extend('force', default_config, source.opts or {})
 end
 
 return Utils

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -31,7 +31,7 @@ end
 
 Utils.create_compe_config = function()
     local source = config.get_source_config('tmux') or {}
-    return vim.tbl_extend('force', default_config, source.opts or {})
+    return vim.tbl_extend('force', default_config, source.option or {})
 end
 
 return Utils

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -29,7 +29,7 @@ end
 
 Utils.create_compe_config = function()
     local source = config.get_source_config('tmux') or {}
-    return vim.tbl_extend('force', default_config, source)
+    return vim.tbl_extend('force', default_config, source.opts)
 end
 
 return Utils

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -28,7 +28,7 @@ Utils.read_command = function(cmd)
 end
 
 Utils.create_compe_config = function()
-    local source = config.get_source_option('tmux') or {}
+    local source = config.get_source_config('tmux') or {}
     return vim.tbl_extend('force', default_config, source)
 end
 

--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -6,7 +6,11 @@
 --
 
 local Utils = {}
-local compe_config = require'compe.config'
+local config = require'cmp.config'
+
+local default_config = {
+    all_panes = false,
+}
 
 Utils.read_command = function(cmd)
     local h = io.popen(cmd)
@@ -23,17 +27,8 @@ Utils.read_command = function(cmd)
 end
 
 Utils.create_compe_config = function()
-    local source = {}
-    local c = compe_config.get()
-
-    if type(c) == 'table' and type(c.source) == 'table' then
-        source = c.source.tmux or {}
-    end
-
-    return vim.tbl_extend('force', {
-        all_panes = false,
-        kind = 'Text'
-    }, source)
+    local source = config.get_source_option('tmux') or {}
+    return vim.tbl_extend('force', default_config, source)
 end
 
 return Utils


### PR DESCRIPTION
This should make this extension run on cmp. This repo will be renamed to `cmp-tmux` and rebased when cmp is ready.... is it ready ?! I can't really tell :man_shrugging: 

**[New installation instructions](https://github.com/andersevenrud/compe-tmux/blob/cmp/README.md)**

Breaking:

- The option `kind` is no longer overridable
- Version support will be inverted, so compe users will have to switch branch

Tasks:

- [x] Update main branch README with notice
- [x] Update new branch README instructions
- [x] Remove obsolete 'kind' configuration
- [x] Migrate source
- [x] Migrate configuration
- [ ] Rebase (`main -> compe`, `cmp -> main`) and rename project when cmp goes out
- [ ] Add `BREAKING` commit message in `main` afterwards and switch info in README

Additional (maybe another PR for this):

- [ ] Add better triggers now that this has a nicer API
- [x] Is it possible to add menu hint like before (`[tmux]`) ? (https://github.com/hrsh7th/nvim-cmp/issues/98)
- [x] ~~Check if there's an internal dedupe?~~ Doesn't really matter anymore by code change
- [ ] Async task in cmp ?