### PR TITLE
Update config.get_source_option function name due to change in nvim-cmp

### DIFF
--- a/lua/compe_tmux/utils.lua
+++ b/lua/compe_tmux/utils.lua
@@ -28,7 +28,7 @@ Utils.read_command = function(cmd)
 end
 
 Utils.create_compe_config = function()
-    local source = config.get_source_option('tmux') or {}
+    local source = config.get_source_config('tmux') or {}
     return vim.tbl_extend('force', default_config, source)
 end
 


### PR DESCRIPTION
`nvim-cmp` changed the name of the config member function `get_source_option` to `get_source_config`. Users of `compe-tmux` would be seeing the error posted in https://github.com/andersevenrud/compe-tmux/issues/10 as of ~3 hours ago. 

Closes https://github.com/andersevenrud/compe-tmux/issues/10